### PR TITLE
Fix nil map panic

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -70,6 +70,7 @@ func ParseDevice(path dbus.ObjectPath, propsMap map[string]dbus.Variant) (*Devic
 		return nil, err
 	}
 	c.Properties = props
+	d.chars = make(map[dbus.ObjectPath]*profile.GattCharacteristic1, 0)
 
 	return d, nil
 }


### PR DESCRIPTION
Hi,
Ran into the problem when code like this panics because the `chars` map is not initialized:
```
api.On("discovery", emitter.NewCallback(func(ev emitter.Event) {
	e := ev.GetData().(api.DiscoveredDeviceEvent)
	e.GetCharByUUID(uuid) // here
}))
```

```
github.com/muka/go-bluetooth/api.(*Device).GetCharByUUID(0x10d916e0, 0x10e1e1e0, 0x24, 0x0, 0x1, 0x1)
github.com/muka/go-bluetooth/api/Device.go:257 +0x358
...
```

This PR fixes it.