### PR TITLE
Determining the path/source of an update makes sorting of notifications easier

### DIFF
--- a/bluez/profile/GattCharacteristic1.go
+++ b/bluez/profile/GattCharacteristic1.go
@@ -20,6 +20,8 @@ func NewGattCharacteristic1(path string) *GattCharacteristic1 {
 		},
 	)
 
+	g.Path = path
+
 	g.Properties = new(GattCharacteristic1Properties)
 
 	_, err := g.GetProperties()
@@ -35,6 +37,7 @@ type GattCharacteristic1 struct {
 	client     *bluez.Client
 	Properties *GattCharacteristic1Properties
 	channel    chan *dbus.Signal
+	Path       string
 }
 
 // GattCharacteristic1Properties exposed properties for GattCharacteristic1


### PR DESCRIPTION
I noticed that when adding a notify to a characteristic, the way of filtering out the non-important messages could be simplified. One way is to add the path as part of the characteristic struct itself. There could be something I'm overlooking here. Let me know!