### PR TITLE
Nil pointer dereference

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -313,15 +313,6 @@ func (d *Device) GetCharsList() []dbus.ObjectPath {
 
 	var chars []dbus.ObjectPath
 
-	if len(d.chars) != 0 {
-
-		for objpath := range d.chars {
-			chars = append(chars, objpath)
-		}
-
-		return chars
-	}
-
 	list := GetManager().GetObjects()
 	for objpath := range *list {
 		path := string(objpath)

--- a/api/Device.go
+++ b/api/Device.go
@@ -301,9 +301,9 @@ func (d *Device) GetCharByUUID(uuid string) (*profile.GattCharacteristic1, error
 		}
 	}
 
-	// if deviceFound == nil {
-	// 	dbgDevice("Characteristic not Found: %s ", uuid)
-	// }
+	if deviceFound == nil {
+    return nil, errors.New("Characteristic not found.")
+	}
 
 	return deviceFound, nil
 }


### PR DESCRIPTION
Related to #28 

This solves the issue of any nil `profile.GattCharacteristic1`from being created and then referenced later on. This does break caching of characteristics though until we can 100% be certain during any stage of a system and connection that we will get all the characteristics when `GetCharsList()` is called the first time.