### PR TITLE
unregister and close dbus channels properly

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -104,6 +104,7 @@ func (d *Device) watchProperties() error {
 	if err != nil {
 		return err
 	}
+	d.watchPropertiesChannel = channel
 
 	go (func() {
 		for {
@@ -157,14 +158,17 @@ func (d *Device) watchProperties() error {
 
 //Device return an API to interact with a DBus device
 type Device struct {
-	Path       string
-	Properties *profile.Device1Properties
-	client     *profile.Device1
-	chars      map[dbus.ObjectPath]*profile.GattCharacteristic1
+	Path                   string
+	Properties             *profile.Device1Properties
+	client                 *profile.Device1
+	chars                  map[dbus.ObjectPath]*profile.GattCharacteristic1
+	watchPropertiesChannel chan *dbus.Signal
 }
 
 func (d *Device) unwatchProperties() error {
-	return d.client.Unregister()
+	err := d.client.Unregister(d.watchPropertiesChannel)
+	close(d.watchPropertiesChannel)
+	return err
 }
 
 //GetClient return a DBus Device1 interface client

--- a/api/Device.go
+++ b/api/Device.go
@@ -99,6 +99,9 @@ func ParseDevice(path dbus.ObjectPath, propsMap map[string]dbus.Variant) (*Devic
 }
 
 func (d *Device) watchProperties() error {
+	if d.watchPropertiesChannel != nil {
+		d.unwatchProperties()
+	}
 
 	channel, err := d.client.Register()
 	if err != nil {
@@ -166,8 +169,13 @@ type Device struct {
 }
 
 func (d *Device) unwatchProperties() error {
-	err := d.client.Unregister(d.watchPropertiesChannel)
-	close(d.watchPropertiesChannel)
+	var err error
+	if d.watchPropertiesChannel != nil {
+		err = d.client.Unregister(d.watchPropertiesChannel)
+		close(d.watchPropertiesChannel)
+		d.watchPropertiesChannel = nil
+	}
+
 	return err
 }
 
@@ -401,6 +409,9 @@ func (d *Device) Disconnect() error {
 		return err
 	}
 	c.Disconnect()
+	if d.watchPropertiesChannel != nil {
+		d.unwatchProperties()
+	}
 	return nil
 }
 

--- a/api/Manager.go
+++ b/api/Manager.go
@@ -58,7 +58,7 @@ func (m *Manager) unwatchChanges() error {
 		close(m.channel)
 	}
 	m.watchChangesEnabled = false
-	return m.objectManager.Unregister()
+	return m.objectManager.Unregister(m.channel)
 }
 
 // watchChanges regitster for signals from the ObjectManager
@@ -243,7 +243,7 @@ func (m *Manager) RefreshState() error {
 
 //Close Close the Manager and free underlying resources
 func (m *Manager) Close() {
-	m.objectManager.Unregister()
+	m.objectManager.Unregister(m.channel)
 	m.objectManager.Close()
 	m.objectManager = nil
 }

--- a/bluez/Client.go
+++ b/bluez/Client.go
@@ -125,7 +125,7 @@ func (c *Client) Register(path string, iface string) (chan *dbus.Signal, error) 
 }
 
 //Unregister for signals
-func (c *Client) Unregister(path string, iface string) error {
+func (c *Client) Unregister(path string, iface string, signal chan *dbus.Signal) error {
 	if !c.isConnected() {
 		err := c.Connect()
 		if err != nil {
@@ -134,6 +134,9 @@ func (c *Client) Unregister(path string, iface string) error {
 	}
 	matchstr := getMatchString(path, iface)
 	c.conn.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, matchstr)
+	if signal != nil {
+		c.conn.RemoveSignal(signal)
+	}
 
 	return nil
 }

--- a/bluez/profile/Device1.go
+++ b/bluez/profile/Device1.go
@@ -63,8 +63,8 @@ func (d *Device1) Register() (chan *dbus.Signal, error) {
 }
 
 //Unregister for changes signalling
-func (d *Device1) Unregister() error {
-	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface)
+func (d *Device1) Unregister(signal chan *dbus.Signal) error {
+	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface, signal)
 }
 
 //GetProperties load all available properties

--- a/bluez/profile/GattCharacteristic1.go
+++ b/bluez/profile/GattCharacteristic1.go
@@ -82,11 +82,11 @@ func (d *GattCharacteristic1) Register() (chan *dbus.Signal, error) {
 }
 
 //Unregister for changes signalling
-func (d *GattCharacteristic1) Unregister() error {
+func (d *GattCharacteristic1) Unregister(signal chan *dbus.Signal) error {
 	if d.channel != nil {
 		close(d.channel)
 	}
-	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface)
+	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface, signal)
 }
 
 //GetProperties load all available properties

--- a/bluez/profile/GattDescriptor1.go
+++ b/bluez/profile/GattDescriptor1.go
@@ -57,8 +57,8 @@ func (d *GattDescriptor1) Register() (chan *dbus.Signal, error) {
 }
 
 //Unregister for changes signalling
-func (d *GattDescriptor1) Unregister() error {
-	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface)
+func (d *GattDescriptor1) Unregister(signal chan *dbus.Signal) error {
+	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface, signal)
 }
 
 //GetProperties load all available properties

--- a/bluez/profile/GattService1.go
+++ b/bluez/profile/GattService1.go
@@ -67,8 +67,8 @@ func (d *GattService1) Register() (chan *dbus.Signal, error) {
 }
 
 //Unregister for changes signalling
-func (d *GattService1) Unregister() error {
-	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface)
+func (d *GattService1) Unregister(signal chan *dbus.Signal) error {
+	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface, signal)
 }
 
 //GetProperties load all available properties

--- a/bluez/profile/ObjectManager.go
+++ b/bluez/profile/ObjectManager.go
@@ -45,8 +45,8 @@ func (o *ObjectManager) Register() (chan *dbus.Signal, error) {
 }
 
 //Unregister watch for signal events
-func (o *ObjectManager) Unregister() error {
+func (o *ObjectManager) Unregister(signal chan *dbus.Signal) error {
 	path := o.client.Config.Path
 	iface := o.client.Config.Iface
-	return o.client.Unregister(path, iface)
+	return o.client.Unregister(path, iface, signal)
 }


### PR DESCRIPTION
I have found a bug in the library affecting the Device.watchProperties go-routine: its signaling channel never gets closed. A proper deregistration from the dbus library was missing as well. As this problem will most probaby be the same for oher structs, I have added a channel parameter to every Unregister function of every struct whose Register function spits out a channel.