### PR TITLE
Fix for DBus introspection of methods

### DIFF
--- a/service/GattCharacteristic1.go
+++ b/service/GattCharacteristic1.go
@@ -131,26 +131,29 @@ func (s *GattCharacteristic1) RemoveDescriptor(char *GattDescriptor1) error {
 }
 
 //ReadValue read a value
-func (s *GattCharacteristic1) ReadValue(options map[string]interface{}) []byte {
+func (s *GattCharacteristic1) ReadValue(options map[string]interface{}) ([]byte, *dbus.Error) {
 	log.Debug("Characteristic.ReadValue")
-	b := make([]byte, 0)
-	return b
+	b := make([]byte, 2)
+	b[0] = 0xff
+	b[1] = 0xff
+	return b, nil
 }
 
 //WriteValue write a value
-func (s *GattCharacteristic1) WriteValue(value []byte, options map[string]interface{}) {
+func (s *GattCharacteristic1) WriteValue(value []byte, options map[string]interface{}) *dbus.Error {
 	log.Debug("Characteristic.WriteValue")
+	return nil
 }
 
 //StartNotify start notification
-func (s *GattCharacteristic1) StartNotify() error {
+func (s *GattCharacteristic1) StartNotify() *dbus.Error {
 	log.Debug("Characteristic.StartNotify")
 	s.notifying = true
 	return nil
 }
 
 //StopNotify stop notification
-func (s *GattCharacteristic1) StopNotify() error {
+func (s *GattCharacteristic1) StopNotify() *dbus.Error {
 	log.Debug("Characteristic.StopNotify")
 	s.notifying = false
 	return nil

--- a/service/GattDescriptor1.go
+++ b/service/GattDescriptor1.go
@@ -64,13 +64,14 @@ func (s *GattDescriptor1) Properties() map[string]bluez.Properties {
 }
 
 //ReadValue read a value
-func (s *GattDescriptor1) ReadValue(options map[string]interface{}) []byte {
+func (s *GattDescriptor1) ReadValue(options map[string]interface{}) ([]byte, *dbus.Error) {
 	b := make([]byte, 0)
-	return b
+	return b, nil
 }
 
 //WriteValue write a value
-func (s *GattDescriptor1) WriteValue(value []byte, options map[string]interface{}) {
+func (s *GattDescriptor1) WriteValue(value []byte, options map[string]interface{}) *dbus.Error {
+	return nil
 }
 
 //Expose the desc to dbus

--- a/service/GattService1.go
+++ b/service/GattService1.go
@@ -114,9 +114,9 @@ func (s *GattService1) AddCharacteristic(char *GattCharacteristic1) error {
 		return err
 	}
 
-	err = s.GetApp().exportTree()
-	if err != nil {
-		return err
+	dberr := s.GetApp().exportTree()
+	if dberr != nil {
+		return nil
 	}
 
 	om := s.config.app.GetObjectManager()

--- a/service/GattService1.go
+++ b/service/GattService1.go
@@ -114,9 +114,9 @@ func (s *GattService1) AddCharacteristic(char *GattCharacteristic1) error {
 		return err
 	}
 
-	dberr := s.GetApp().exportTree()
-	if dberr != nil {
-		return nil
+	err = s.GetApp().exportTree()
+	if err != nil {
+		return err
 	}
 
 	om := s.config.app.GetObjectManager()


### PR DESCRIPTION
The introspection expects any exported methods to have a dbus.Error pointer as the final output, but the ReadValue/WriteValue and similar methods do not presently have this format.  Changing the method signatures causes them to work properly.

This fixes #30 in the repository issues list.

(Unfortunately, the service package still needs a fair amount of work; right now, the subscription and notification functionality doesn't really work properly, nor is there any easy way to actually provide or get values from a GattCharacteristic1.  But at least this corrects that one issue.)