### PR TITLE
First cut of fully working service functionality

### DIFF
--- a/bluez/profile/GattCharacteristic1.go
+++ b/bluez/profile/GattCharacteristic1.go
@@ -41,7 +41,7 @@ type GattCharacteristic1 struct {
 
 // GattCharacteristic1Properties exposed properties for GattCharacteristic1
 type GattCharacteristic1Properties struct {
-	Value          []byte
+	Value          []byte `dbus:"emit"`
 	Notifying      bool
 	NotifyAcquired bool
 	WriteAcquired  bool

--- a/bluez/profile/GattDescriptor1.go
+++ b/bluez/profile/GattDescriptor1.go
@@ -32,7 +32,7 @@ type GattDescriptor1 struct {
 
 // GattDescriptor1Properties exposed properties for GattDescriptor1
 type GattDescriptor1Properties struct {
-	Value          []byte
+	Value          []byte `dbus:"emit"`
 	Characteristic dbus.ObjectPath
 	UUID           string
 	Flags          []string

--- a/service/Application.go
+++ b/service/Application.go
@@ -51,12 +51,12 @@ func NewApplication(config *ApplicationConfig) (*Application, error) {
 }
 
 // A callback we can register to handle write requests
-type GattWriteCallback func(service_uuid string, char_uuid string, value []byte) error
-type GattDescriptorWriteCallback func(service_uuid string, char_uuid string, desc_uuid string, value []byte) error
+type GattWriteCallback func(app *Application, service_uuid string, char_uuid string, value []byte) error
+type GattDescriptorWriteCallback func(app *Application, service_uuid string, char_uuid string, desc_uuid string, value []byte) error
 
 // A callback we can register to handle read requests
-type GattReadCallback func(service_uuid string, char_uuid string) ([]byte, error)
-type GattDescriptorReadCallback func(service_uuid string, char_uuid string, desc_uuid string) ([]byte, error)
+type GattReadCallback func(app *Application, service_uuid string, char_uuid string) ([]byte, error)
+type GattDescriptorReadCallback func(app *Application, service_uuid string, char_uuid string, desc_uuid string) ([]byte, error)
 
 // ApplicationConfig configuration for the bluetooth service
 type ApplicationConfig struct {
@@ -256,7 +256,7 @@ func (app *Application) HandleRead(srv_uuid string, uuid string) ([]byte, *Callb
 	}
 
 	var cberr *CallbackError = nil
-	b, err := app.config.ReadFunc(srv_uuid, uuid)
+	b, err := app.config.ReadFunc(app, srv_uuid, uuid)
 	if err != nil {
 		cberr = NewCallbackError(-2, err.Error())
 	}
@@ -269,7 +269,7 @@ func (app *Application) HandleWrite(srv_uuid string, uuid string, value []byte) 
 		return NewCallbackError(-1, "No callback registered.")
 	}
 
-	err := app.config.WriteFunc(srv_uuid, uuid, value)
+	err := app.config.WriteFunc(app, srv_uuid, uuid, value)
 	if err != nil {
 		return NewCallbackError(-2, err.Error())
 	}
@@ -284,7 +284,7 @@ func (app *Application) HandleDescriptorRead(srv_uuid string, char_uuid string, 
 	}
 
 	var cberr *CallbackError = nil
-	b, err := app.config.DescReadFunc(srv_uuid, char_uuid, desc_uuid)
+	b, err := app.config.DescReadFunc(app, srv_uuid, char_uuid, desc_uuid)
 	if err != nil {
 		cberr = NewCallbackError(-2, err.Error())
 	}
@@ -297,7 +297,7 @@ func (app *Application) HandleDescriptorWrite(srv_uuid string, char_uuid string,
 		return NewCallbackError(-1, "No callback registered.")
 	}
 
-	err := app.config.DescWriteFunc(srv_uuid, char_uuid, desc_uuid, value)
+	err := app.config.DescWriteFunc(app, srv_uuid, char_uuid, desc_uuid, value)
 	if err != nil {
 		return NewCallbackError(-2, err.Error())
 	}

--- a/service/GattDescriptor1.go
+++ b/service/GattDescriptor1.go
@@ -65,13 +65,47 @@ func (s *GattDescriptor1) Properties() map[string]bluez.Properties {
 
 //ReadValue read a value
 func (s *GattDescriptor1) ReadValue(options map[string]interface{}) ([]byte, *dbus.Error) {
-	b := make([]byte, 0)
-	return b, nil
+	b, err := s.config.characteristic.config.service.config.app.HandleDescriptorRead(
+		s.config.characteristic.config.service.properties.UUID, s.config.characteristic.properties.UUID,
+		s.properties.UUID)
+
+	var dberr *dbus.Error = nil
+
+	if err != nil {
+		if err.code == -1 {
+			// No registered callback, so we'll just use our stored value
+			b = s.properties.Value
+		} else {
+			dberr = dbus.NewError(err.Error(), nil)
+		}
+	}
+
+	return b, dberr
 }
 
 //WriteValue write a value
 func (s *GattDescriptor1) WriteValue(value []byte, options map[string]interface{}) *dbus.Error {
+	err := s.config.characteristic.config.service.config.app.HandleDescriptorWrite(
+		s.config.characteristic.config.service.properties.UUID, s.config.characteristic.properties.UUID,
+		s.properties.UUID, value)
+
+	if err != nil {
+		if err.code == -1 {
+			// No registered callback, so we'll just store this value
+			s.UpdateValue(value)
+			return nil
+		} else {
+			dberr := dbus.NewError(err.Error(), nil)
+			return dberr
+		}
+	}
+
 	return nil
+}
+
+func (s *GattDescriptor1) UpdateValue(value []byte) {
+	s.properties.Value = value
+	s.PropertiesInterface.Instance().Set(s.Interface(), "Value", dbus.MakeVariant(value))
 }
 
 //Expose the desc to dbus


### PR DESCRIPTION
Add Read/Write callbacks (to allow dynamic data), and UpdateValue which can actually handle notifications properly.

By default, if no callbacks are added to the application, characteristics and descriptors will just store the value written to them (if writable), return the current value (if readable), and allow the value to be updated via UpdateValue() calls (which will notify any subscribers).  If callbacks are added, all behavior is up to the callback (writing to a characteristic does not necessarily update a value).

This is not _extensively_ tested, but seems to work better than the previous cut.  Might want to decide whether the callbacks are the best method of doing completely dynamic behavior on Write/Read.