### PR TITLE
Fixed upstream URL of logrus

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.5"
 
 [[constraint]]

--- a/api/Manager.go
+++ b/api/Manager.go
@@ -3,7 +3,7 @@ package api
 import (
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile"

--- a/bluez/profile/GattManager1.go
+++ b/bluez/profile/GattManager1.go
@@ -1,9 +1,9 @@
 package profile
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/muka/go-bluetooth/bluez"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewGattManager1 create a new GattManager1 client

--- a/bluez/profile/obex/ObexClient1.go
+++ b/bluez/profile/obex/ObexClient1.go
@@ -1,9 +1,9 @@
 package obex
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/muka/go-bluetooth/bluez"
+	log "github.com/sirupsen/logrus"
 )
 
 // TODO: https://github.com/blueman-project/blueman/issues/218#issuecomment-89315974

--- a/devices/sensortag.go
+++ b/devices/sensortag.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile"

--- a/examples/btmgmt/main.go
+++ b/examples/btmgmt/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/linux"
 )
 

--- a/examples/discovery/main.go
+++ b/examples/discovery/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/emitter"
 	"github.com/muka/go-bluetooth/linux"

--- a/examples/hci_updown/main.go
+++ b/examples/hci_updown/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/linux"
 )
 

--- a/examples/obex_push/main.go
+++ b/examples/obex_push/main.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile/obex"
 )

--- a/examples/sensortag_info/main.go
+++ b/examples/sensortag_info/main.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/devices"
 	"github.com/muka/go-bluetooth/emitter"

--- a/examples/sensortag_temperature/main.go
+++ b/examples/sensortag_temperature/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/devices"

--- a/examples/service/client.go
+++ b/examples/service/client.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile"
 	"github.com/muka/go-bluetooth/emitter"

--- a/examples/service/main.go
+++ b/examples/service/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/examples/service/service.go
+++ b/examples/service/service.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile"
 	"github.com/muka/go-bluetooth/service"
+	log "github.com/sirupsen/logrus"
 )
 
 func registerApplication() error {

--- a/examples/show_info/main.go
+++ b/examples/show_info/main.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile"
+	log "github.com/sirupsen/logrus"
 )
 
 //ShowInfoExample show informations for hardcoded MiBand2 on hci0

--- a/examples/watch_changes/main.go
+++ b/examples/watch_changes/main.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/emitter"
 	"github.com/muka/go-bluetooth/linux"
+	log "github.com/sirupsen/logrus"
 )
 
 var adapterID = "hci0"

--- a/linux/cmdexec.go
+++ b/linux/cmdexec.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"os/exec"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // CmdExec Execute a command

--- a/linux/rfkill.go
+++ b/linux/rfkill.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func limitText(text []byte) string {

--- a/service/GattCharacteristic1.go
+++ b/service/GattCharacteristic1.go
@@ -3,7 +3,7 @@ package service
 import (
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/godbus/dbus/introspect"
 	"github.com/godbus/dbus/prop"

--- a/service/ObjectManager.go
+++ b/service/ObjectManager.go
@@ -3,7 +3,7 @@ package service
 import (
 	"errors"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/muka/go-bluetooth/bluez"
 )

--- a/service/Properties.go
+++ b/service/Properties.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/fatih/structs"
 	"github.com/godbus/dbus"
 	"github.com/godbus/dbus/introspect"


### PR DESCRIPTION
The upstream repository URL of logrus has changed a few months ago. Quoting logrus's README:

```
The organization's name was changed to lower-case--and this will not be changed back. If you are getting import conflicts due to case sensitivity, please use the lower-case import: github.com/sirupsen/logrus.
```

Sadly this naming collision makes it impossible to use go-bluetooth alongside any other dependency that already imports the canonical URL with the lowercase 'sirupsen'.