### PR TITLE
filter not related to device PropertiesChangedchange events

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -125,6 +125,9 @@ func (d *Device) watchProperties() error {
 			if sig.Name != bluez.PropertiesChanged {
 				continue
 			}
+			if (fmt.Sprint(sig.Path) != d.Path) {
+			    continue
+			}
 
 			// for i := 0; i < len(sig.Body); i++ {
 			// log.Printf("%s -> %s\n", reflect.TypeOf(sig.Body[i]), sig.Body[i])


### PR DESCRIPTION
If device object expose a Device.On method which internally calls Device.watchProperties, it is natural that we expected changes related only to this device, not to all other devices. This change adds filtering by Signal.Path in watcher go routine.