### PR TITLE
Added FlushDevices to remove and clear cached devices

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -64,6 +64,31 @@ func ClearDevice(d *Device) error {
 	return nil
 }
 
+// FlushDevices clears removes device and clears it from cached devices
+func FlushDevices(adapterID string) error {
+	adapter, err := GetAdapter(adapterID)
+	if err != nil {
+		return err
+	}
+
+	devices, err := GetDevices()
+	if err != nil {
+		return err
+	}
+	for _, dev := range devices {
+		err = adapter.RemoveDevice(dev.Path)
+		if err != nil {
+			return err
+		}
+
+		err := ClearDevice(&dev)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 //ClearDevices clear cached devices
 func ClearDevices() error {
 	devices, err := GetDevices()
@@ -125,8 +150,8 @@ func (d *Device) watchProperties() error {
 			if sig.Name != bluez.PropertiesChanged {
 				continue
 			}
-			if (fmt.Sprint(sig.Path) != d.Path) {
-			    continue
+			if fmt.Sprint(sig.Path) != d.Path {
+				continue
 			}
 
 			// for i := 0; i < len(sig.Body); i++ {

--- a/examples/discovery/main.go
+++ b/examples/discovery/main.go
@@ -4,10 +4,10 @@ package main
 import (
 	"os"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/emitter"
 	"github.com/muka/go-bluetooth/linux"
+	log "github.com/sirupsen/logrus"
 )
 
 const logLevel = log.DebugLevel
@@ -23,6 +23,12 @@ func main() {
 	log.Debugf("Reset bluetooth device")
 	a := linux.NewBtMgmt(adapterID)
 	err := a.Reset()
+	if err != nil {
+		log.Error(err)
+		os.Exit(1)
+	}
+
+	err = api.FlushDevices(adapterID)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)


### PR DESCRIPTION
I found that calling api.ClearDevices caused an issue with subsequent device calls (especially api.GetDevices()) as api.GetDeviceList's call to Manager.GetObjects|() would return objects that had been cleared from the cache) would fail.

Calling Flush calls adapter.RemoveDevice(...) as well as clearing it.

I have updated the discovery example to show its use, and prove that it works.