### PR TITLE
bug fix and test AgentManager1

### DIFF
--- a/api/Device.go
+++ b/api/Device.go
@@ -449,6 +449,5 @@ func (d *Device) Pair() error {
 	if err != nil {
 		return err
 	}
-	c.Pair()
-	return nil
+	return c.Pair()
 }

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"errors"
-
+  "fmt"
 	"github.com/godbus/dbus"
 
 	"github.com/muka/go-bluetooth/bluez"
@@ -38,6 +38,7 @@ func GetDevices() ([]Device, error) {
 
 	list, err := GetDeviceList()
 	if err != nil {
+	  fmt.Println("GetDeviceList", err)
 		return nil, err
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"errors"
-  "fmt"
 	"github.com/godbus/dbus"
 
 	"github.com/muka/go-bluetooth/bluez"
@@ -38,7 +37,6 @@ func GetDevices() ([]Device, error) {
 
 	list, err := GetDeviceList()
 	if err != nil {
-	  fmt.Println("GetDeviceList", err)
 		return nil, err
 	}
 

--- a/bluez/Client.go
+++ b/bluez/Client.go
@@ -79,7 +79,7 @@ func (c *Client) SetProperty(p string, v interface{}) error {
 			return err
 		}
 	}
-	return c.dbusObject.Call("org.freedesktop.DBus.Properties.Set", 0, c.Config.Iface, p, v).Store()
+	return c.dbusObject.Call("org.freedesktop.DBus.Properties.Set", 0, c.Config.Iface, p, dbus.MakeVariant(v)).Store()
 }
 
 //GetProperties load all the properties for an interface

--- a/bluez/profile/AgentManager1.go
+++ b/bluez/profile/AgentManager1.go
@@ -2,10 +2,11 @@ package profile
 
 import (
 	"github.com/godbus/dbus"
+  "github.com/godbus/dbus/prop"
+	"github.com/godbus/dbus/introspect"
 	"github.com/muka/go-bluetooth/bluez"
 )
 
-/*
 //All agent capabilities 
 const (
 	AGENT_CAP_DISPLAY_ONLY       = "DisplayOnly"
@@ -14,7 +15,21 @@ const (
 	AGENT_CAP_NO_INPUT_NO_OUTPUT = "NoInputNoOutput"
 	AGENT_CAP_KEYBOARD_DISPLAY   = "KeyboardDisplay"
 )
-*/
+
+type Agent1Interface interface {
+	Release() *dbus.Error // Callback doesn't trigger on unregister
+	RequestPinCode(device dbus.ObjectPath) (pincode string, err *dbus.Error) // Triggers for pairing when SSP is off and cap != CAP_NO_INPUT_NO_OUTPUT
+	DisplayPinCode(device dbus.ObjectPath, pincode string) *dbus.Error
+	RequestPasskey(device dbus.ObjectPath)  (passkey uint32, err *dbus.Error) // SSP on, toolz.AGENT_CAP_KEYBOARD_ONLY
+	DisplayPasskey(device dbus.ObjectPath, passkey uint32, entered uint16) *dbus.Error
+	RequestConfirmation(device dbus.ObjectPath, passkey uint32) *dbus.Error
+	RequestAuthorization(device dbus.ObjectPath) *dbus.Error
+	AuthorizeService(device dbus.ObjectPath, uuid string) *dbus.Error
+	Cancel() *dbus.Error
+	RegistrationPath() string
+	InterfacePath() string
+}
+
 // NewAgentManager1 create a new AgentManager1 client
 func NewAgentManager1(hostID string) *AgentManager1 {
 	a := new(AgentManager1)
@@ -54,3 +69,45 @@ func (a *AgentManager1) RequestDefaultAgent(agent string) error {
 func (a *AgentManager1) UnregisterAgent(agent string) error {
 	return a.client.Call("UnregisterAgent", 0, dbus.ObjectPath(agent)).Store()
 }
+
+//ExportGoAgentToDBus exports the xml of go agent to dbus
+func (a *AgentManager1) ExportGoAgentToDBus(agentInstance Agent1Interface) error {
+
+	//Connect DBus System bus
+	conn,err := dbus.SystemBus()
+	if err != nil { return err }
+	
+  targetPath := agentInstance.RegistrationPath()
+  agentInterfacePath := agentInstance.InterfacePath()
+
+	//Export the given agent to the given path as interface "org.bluez.Agent1"
+	err = conn.Export(agentInstance, dbus.ObjectPath(targetPath), agentInterfacePath)
+	if err != nil { return err }
+
+	// Create  Introspectable for the given agent instance
+	node := &introspect.Node{
+		Interfaces: []introspect.Interface{
+			// Introspect
+			introspect.IntrospectData,
+			// Properties
+			prop.IntrospectData,
+			// org.bluez.Agent1
+			{
+				Name:    agentInterfacePath,
+				Methods: introspect.Methods(agentInstance),
+			},
+		},
+
+	}
+	//fmt.Println(node)
+
+	// Export Introspectable for the given agent instance
+	err = conn.Export(introspect.NewIntrospectable(node), dbus.ObjectPath(targetPath), "org.freedesktop.DBus.Introspectable")
+	if err != nil {
+		return err
+	}
+	return nil
+
+}
+
+


### PR DESCRIPTION
api/Device.go
Pair() needs to  do a  return job to indicate the status of pairing ,like failed ,etc

bluez/Client.go
dbus.MakeVariant() is required to make the interface v to be an acceptable data format for dbus 

bluez/profile/AgentManager1.go
changed a lot, I wrote a test program called simple_agent.go this afternoon use this AgentManager1.go
well tested ,no problem with duplicate paring, and paring also return the result
but there will be a issue: no where to control the paring timeout 

my test program is here:

https://gist.github.com/cuu/a43f0c0c666e4ea61e3dece310803318

just change the **dev_mac** of your device  in main() 
I use logitech bluetooth keyboard K480 for testing 
works well

Sorry if there are  any questions, including code style, please modify them freely
I don't understand your code quiet well yet. 

:)
