### PR TITLE
Pass through *CallbackError created in read and write handlers

### DIFF
--- a/service/Application.go
+++ b/service/Application.go
@@ -277,17 +277,17 @@ const CallbackFunctionError = -2
 func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *CallbackError) {
 	if app.config.ReadFunc == nil {
 		b := make([]byte, 0)
-		return b, NewCallbackError(-1, "No callback registered.")
+		return b, NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	var cberr *CallbackError
 	b, err := app.config.ReadFunc(app, srvUUID, uuid)
 	if err != nil {
-		// If a CallbackError is returned, simply pass it through
 		if err, ok := err.(*CallbackError); ok {
+			// If a CallbackError is returned, simply pass it through
 			cberr = err
 		} else {
-			cberr = NewCallbackError(-2, err.Error())
+			cberr = NewCallbackError(CallbackFunctionError, err.Error())
 		}
 	}
 
@@ -297,17 +297,17 @@ func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *Callba
 // HandleWrite handle application write
 func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *CallbackError {
 	if app.config.WriteFunc == nil {
-		return NewCallbackError(-1, "No callback registered.")
+		return NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	err := app.config.WriteFunc(app, srvUUID, uuid, value)
 	if err != nil {
-		// If a CallbackError is returned, simply pass it through
 		if err, ok := err.(*CallbackError); ok {
+			// If a CallbackError is returned, simply pass it through
 			return err
 		}
 
-		return NewCallbackError(-2, err.Error())
+		return NewCallbackError(CallbackFunctionError, err.Error())
 	}
 
 	return nil
@@ -317,17 +317,17 @@ func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *
 func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, descUUID string) ([]byte, *CallbackError) {
 	if app.config.DescReadFunc == nil {
 		b := make([]byte, 0)
-		return b, NewCallbackError(-1, "No callback registered.")
+		return b, NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	var cberr *CallbackError
 	b, err := app.config.DescReadFunc(app, srvUUID, charUUID, descUUID)
 	if err != nil {
-		// If a CallbackError is returned, simply pass it through
 		if err, ok := err.(*CallbackError); ok {
+			// If a CallbackError is returned, simply pass it through
 			cberr = err
 		} else {
-			cberr = NewCallbackError(-2, err.Error())
+			cberr = NewCallbackError(CallbackFunctionError, err.Error())
 		}
 	}
 
@@ -337,17 +337,17 @@ func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, de
 //HandleDescriptorWrite handle descriptor write
 func (app *Application) HandleDescriptorWrite(srvUUID string, charUUID string, descUUID string, value []byte) *CallbackError {
 	if app.config.DescWriteFunc == nil {
-		return NewCallbackError(-1, "No callback registered.")
+		return NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	err := app.config.DescWriteFunc(app, srvUUID, charUUID, descUUID, value)
 	if err != nil {
-		// If a CallbackError is returned, simply pass it through
 		if err, ok := err.(*CallbackError); ok {
+			// If a CallbackError is returned, simply pass it through
 			return err
 		}
 
-		return NewCallbackError(-2, err.Error())
+		return NewCallbackError(CallbackFunctionError, err.Error())
 	}
 
 	return nil

--- a/service/Application.go
+++ b/service/Application.go
@@ -283,9 +283,9 @@ func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *Callba
 	var cberr *CallbackError
 	b, err := app.config.ReadFunc(app, srvUUID, uuid)
 	if err != nil {
-		if err, ok := err.(*CallbackError); ok {
+		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
-			cberr = err
+			cberr = callbackErr
 		} else {
 			cberr = NewCallbackError(CallbackFunctionError, err.Error())
 		}
@@ -302,9 +302,9 @@ func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *
 
 	err := app.config.WriteFunc(app, srvUUID, uuid, value)
 	if err != nil {
-		if err, ok := err.(*CallbackError); ok {
+		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
-			return err
+			return callbackErr
 		}
 
 		return NewCallbackError(CallbackFunctionError, err.Error())
@@ -323,9 +323,9 @@ func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, de
 	var cberr *CallbackError
 	b, err := app.config.DescReadFunc(app, srvUUID, charUUID, descUUID)
 	if err != nil {
-		if err, ok := err.(*CallbackError); ok {
+		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
-			cberr = err
+			cberr = callbackErr
 		} else {
 			cberr = NewCallbackError(CallbackFunctionError, err.Error())
 		}
@@ -342,9 +342,9 @@ func (app *Application) HandleDescriptorWrite(srvUUID string, charUUID string, d
 
 	err := app.config.DescWriteFunc(app, srvUUID, charUUID, descUUID, value)
 	if err != nil {
-		if err, ok := err.(*CallbackError); ok {
+		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
-			return err
+			return callbackErr
 		}
 
 		return NewCallbackError(CallbackFunctionError, err.Error())

--- a/service/Application.go
+++ b/service/Application.go
@@ -283,7 +283,12 @@ func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *Callba
 	var cberr *CallbackError
 	b, err := app.config.ReadFunc(app, srvUUID, uuid)
 	if err != nil {
-		cberr = NewCallbackError(-2, err.Error())
+		// If a CallbackError is returned, simply pass it through
+		if err, ok := err.(*CallbackError); ok {
+			cberr = err
+		} else {
+			cberr = NewCallbackError(-2, err.Error())
+		}
 	}
 
 	return b, cberr
@@ -297,6 +302,11 @@ func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *
 
 	err := app.config.WriteFunc(app, srvUUID, uuid, value)
 	if err != nil {
+		// If a CallbackError is returned, simply pass it through
+		if err, ok := err.(*CallbackError); ok {
+			return err
+		}
+
 		return NewCallbackError(-2, err.Error())
 	}
 
@@ -313,7 +323,12 @@ func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, de
 	var cberr *CallbackError
 	b, err := app.config.DescReadFunc(app, srvUUID, charUUID, descUUID)
 	if err != nil {
-		cberr = NewCallbackError(-2, err.Error())
+		// If a CallbackError is returned, simply pass it through
+		if err, ok := err.(*CallbackError); ok {
+			cberr = err
+		} else {
+			cberr = NewCallbackError(-2, err.Error())
+		}
 	}
 
 	return b, cberr
@@ -327,6 +342,11 @@ func (app *Application) HandleDescriptorWrite(srvUUID string, charUUID string, d
 
 	err := app.config.DescWriteFunc(app, srvUUID, charUUID, descUUID, value)
 	if err != nil {
+		// If a CallbackError is returned, simply pass it through
+		if err, ok := err.(*CallbackError); ok {
+			return err
+		}
+
 		return NewCallbackError(-2, err.Error())
 	}
 

--- a/service/GattCharacteristic1.go
+++ b/service/GattCharacteristic1.go
@@ -138,7 +138,7 @@ func (s *GattCharacteristic1) ReadValue(options map[string]interface{}) ([]byte,
 
 	var dberr *dbus.Error
 	if err != nil {
-		if err.code == -1 {
+		if err.code == CallbackNotRegistered {
 			// No registered callback, so we'll just use our stored value
 			b = s.properties.Value
 		} else {
@@ -156,7 +156,7 @@ func (s *GattCharacteristic1) WriteValue(value []byte, options map[string]interf
 	err := s.config.service.config.app.HandleWrite(s.config.service.properties.UUID, s.properties.UUID, value)
 
 	if err != nil {
-		if err.code == -1 {
+		if err.code == CallbackNotRegistered {
 			// No registered callback, so we'll just store this value
 			s.UpdateValue(value)
 			return nil


### PR DESCRIPTION
It would be great if it was possible to combine characteristics and descriptors with fixed `Value`s and those that are read and wrote to through the read and write handlers.

For that, I had to make a slight change in my fork of this project, so that when a handler returns a `service.NewCallbackError(service.CallbackNotRegistered, "")`, the `*CallbackError` gets passed through, so that the `Value` is used.

```
// my example read handler
func (a *gattApp) handleRead(app *service.Application, serviceUuid string, characteristicUuid string) ([]byte, error) {
	if readHandler, ok := a.readHandlers[characteristicUuid]; ok {
		return readHandler()
	}

	return nil, service.NewCallbackError(service.CallbackNotRegistered, "No callback registered.")
}
```