### PR TITLE
simplify profile.GattCharacteristic1 Register/Unregister

### DIFF
--- a/bluez/profile/GattCharacteristic1.go
+++ b/bluez/profile/GattCharacteristic1.go
@@ -35,7 +35,6 @@ func NewGattCharacteristic1(path string) (*GattCharacteristic1, error) {
 type GattCharacteristic1 struct {
 	client     *bluez.Client
 	Properties *GattCharacteristic1Properties
-	channel    chan *dbus.Signal
 	Path       string
 }
 
@@ -71,21 +70,11 @@ func (d *GattCharacteristic1) Close() {
 
 //Register for changes signalling
 func (d *GattCharacteristic1) Register() (chan *dbus.Signal, error) {
-	if d.channel == nil {
-		channel, err := d.client.Register(d.client.Config.Path, bluez.PropertiesInterface)
-		if err != nil {
-			return nil, err
-		}
-		d.channel = channel
-	}
-	return d.channel, nil
+	return d.client.Register(d.client.Config.Path, bluez.PropertiesInterface)
 }
 
 //Unregister for changes signalling
 func (d *GattCharacteristic1) Unregister(signal chan *dbus.Signal) error {
-	if d.channel != nil {
-		close(d.channel)
-	}
 	return d.client.Unregister(d.client.Config.Path, bluez.PropertiesInterface, signal)
 }
 


### PR DESCRIPTION
remove private channel in GattCharacteristic1, simplify Register()/Unregister():
- registering again after unregistering doesn't work - d.channel is not nil after Unregister(), but it's closed
- comparing to profile.Device's Register/Unregister this is unnecessarily different

 remove it altogether, let user close the channel after unregistering.