### PR TITLE
Use GATT attributes dbus object-paths instead of UUIDs in application's Read / Write callbacks

### DIFF
--- a/service/Application.go
+++ b/service/Application.go
@@ -55,16 +55,16 @@ func NewApplication(config *ApplicationConfig) (*Application, error) {
 }
 
 //GattWriteCallback A callback we can register to handle write requests
-type GattWriteCallback func(app *Application, service_uuid string, charUUID string, value []byte) error
+type GattWriteCallback func(app *Application, serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, value []byte) error
 
 //GattDescriptorWriteCallback A callback we can register to handle descriptor write requests
-type GattDescriptorWriteCallback func(app *Application, service_uuid string, charUUID string, descUUID string, value []byte) error
+type GattDescriptorWriteCallback func(app *Application, serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, descObjPath dbus.ObjectPath, value []byte) error
 
 //GattReadCallback A callback we can register to handle read requests
-type GattReadCallback func(app *Application, service_uuid string, charUUID string) ([]byte, error)
+type GattReadCallback func(app *Application, serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath) ([]byte, error)
 
 //GattDescriptorReadCallback A callback we can register to handle descriptor ead requests
-type GattDescriptorReadCallback func(app *Application, service_uuid string, charUUID string, descUUID string) ([]byte, error)
+type GattDescriptorReadCallback func(app *Application, serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, descObjPath dbus.ObjectPath) ([]byte, error)
 
 // ApplicationConfig configuration for the bluetooth service
 type ApplicationConfig struct {
@@ -274,14 +274,14 @@ const CallbackNotRegistered = -1
 const CallbackFunctionError = -2
 
 //HandleRead Handle application read
-func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *CallbackError) {
+func (app *Application) HandleRead(serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath) ([]byte, *CallbackError) {
 	if app.config.ReadFunc == nil {
 		b := make([]byte, 0)
 		return b, NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	var cberr *CallbackError
-	b, err := app.config.ReadFunc(app, srvUUID, uuid)
+	b, err := app.config.ReadFunc(app, serviceObjPath, charObjPath)
 	if err != nil {
 		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
@@ -295,12 +295,12 @@ func (app *Application) HandleRead(srvUUID string, uuid string) ([]byte, *Callba
 }
 
 // HandleWrite handle application write
-func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *CallbackError {
+func (app *Application) HandleWrite(serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, value []byte) *CallbackError {
 	if app.config.WriteFunc == nil {
 		return NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
-	err := app.config.WriteFunc(app, srvUUID, uuid, value)
+	err := app.config.WriteFunc(app, serviceObjPath, charObjPath, value)
 	if err != nil {
 		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
@@ -314,14 +314,14 @@ func (app *Application) HandleWrite(srvUUID string, uuid string, value []byte) *
 }
 
 //HandleDescriptorRead handle descriptor read
-func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, descUUID string) ([]byte, *CallbackError) {
+func (app *Application) HandleDescriptorRead(serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, descObjPath dbus.ObjectPath) ([]byte, *CallbackError) {
 	if app.config.DescReadFunc == nil {
 		b := make([]byte, 0)
 		return b, NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
 	var cberr *CallbackError
-	b, err := app.config.DescReadFunc(app, srvUUID, charUUID, descUUID)
+	b, err := app.config.DescReadFunc(app, serviceObjPath, charObjPath, descObjPath)
 	if err != nil {
 		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through
@@ -335,12 +335,12 @@ func (app *Application) HandleDescriptorRead(srvUUID string, charUUID string, de
 }
 
 //HandleDescriptorWrite handle descriptor write
-func (app *Application) HandleDescriptorWrite(srvUUID string, charUUID string, descUUID string, value []byte) *CallbackError {
+func (app *Application) HandleDescriptorWrite(serviceObjPath dbus.ObjectPath, charObjPath dbus.ObjectPath, descObjPath dbus.ObjectPath, value []byte) *CallbackError {
 	if app.config.DescWriteFunc == nil {
 		return NewCallbackError(CallbackNotRegistered, "No callback registered.")
 	}
 
-	err := app.config.DescWriteFunc(app, srvUUID, charUUID, descUUID, value)
+	err := app.config.DescWriteFunc(app, serviceObjPath, charObjPath, descObjPath, value)
 	if err != nil {
 		if callbackErr, ok := err.(*CallbackError); ok {
 			// If a CallbackError is returned, simply pass it through

--- a/service/GattCharacteristic1.go
+++ b/service/GattCharacteristic1.go
@@ -3,12 +3,12 @@ package service
 import (
 	"strconv"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/godbus/dbus"
 	"github.com/godbus/dbus/introspect"
 	"github.com/godbus/dbus/prop"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile"
+	log "github.com/sirupsen/logrus"
 )
 
 // NewGattCharacteristic1 create a new GattCharacteristic1 client
@@ -134,7 +134,7 @@ func (s *GattCharacteristic1) RemoveDescriptor(char *GattDescriptor1) error {
 func (s *GattCharacteristic1) ReadValue(options map[string]interface{}) ([]byte, *dbus.Error) {
 	log.Debug("Characteristic.ReadValue")
 
-	b, err := s.config.service.config.app.HandleRead(s.config.service.properties.UUID, s.properties.UUID)
+	b, err := s.config.service.config.app.HandleRead(s.config.service.Path(), s.Path())
 
 	var dberr *dbus.Error
 	if err != nil {
@@ -153,7 +153,7 @@ func (s *GattCharacteristic1) ReadValue(options map[string]interface{}) ([]byte,
 func (s *GattCharacteristic1) WriteValue(value []byte, options map[string]interface{}) *dbus.Error {
 	log.Debug("Characteristic.WriteValue")
 
-	err := s.config.service.config.app.HandleWrite(s.config.service.properties.UUID, s.properties.UUID, value)
+	err := s.config.service.config.app.HandleWrite(s.config.service.Path(), s.Path(), value)
 
 	if err != nil {
 		if err.code == CallbackNotRegistered {

--- a/service/GattDescriptor1.go
+++ b/service/GattDescriptor1.go
@@ -66,8 +66,8 @@ func (s *GattDescriptor1) Properties() map[string]bluez.Properties {
 //ReadValue read a value
 func (s *GattDescriptor1) ReadValue(options map[string]interface{}) ([]byte, *dbus.Error) {
 	b, err := s.config.characteristic.config.service.config.app.HandleDescriptorRead(
-		s.config.characteristic.config.service.properties.UUID, s.config.characteristic.properties.UUID,
-		s.properties.UUID)
+		s.config.characteristic.config.service.Path(), s.config.characteristic.Path(),
+		s.Path())
 
 	var dberr *dbus.Error
 	if err != nil {
@@ -85,8 +85,8 @@ func (s *GattDescriptor1) ReadValue(options map[string]interface{}) ([]byte, *db
 //WriteValue write a value
 func (s *GattDescriptor1) WriteValue(value []byte, options map[string]interface{}) *dbus.Error {
 	err := s.config.characteristic.config.service.config.app.HandleDescriptorWrite(
-		s.config.characteristic.config.service.properties.UUID, s.config.characteristic.properties.UUID,
-		s.properties.UUID, value)
+		s.config.characteristic.config.service.Path(), s.config.characteristic.Path(),
+		s.Path(), value)
 
 	if err != nil {
 		if err.code == -1 {


### PR DESCRIPTION

- While using automation IO service, we can have multiple digital and analog characteristics. Each digital and analog characteristic has UUID 0x2A56 and 0x2A58 respectively.
- Problem : it was not possible to identify that which analog or digital characteristic has been changed. This is because, we have application callbacks where we use characteristic UUID
to identify the characteristic that has been changed.
- To fix this problem, dbus.ObjectPath are used instead of UUIDs of service, characteristic and descriptor. DBus object paths are guaranteed to be unique.