### PR TITLE
fix gatt service Device property type

### DIFF
--- a/bluez/profile/gatt/gen_GattService1.go
+++ b/bluez/profile/gatt/gen_GattService1.go
@@ -78,7 +78,7 @@ type GattService1Properties struct {
 			belongs to. Only present on services from remote
 			devices.
 	*/
-	Device []dbus.ObjectPath `dbus:"ignore=IsService"`
+	Device dbus.ObjectPath `dbus:"ignore=IsService"`
 
 	/*
 	Includes Array of object paths representing the included


### PR DESCRIPTION
Hi, 
I had an error saying :
MapToStruct: Mismatching types for field=Device object=[]dbus.ObjectPath props=dbus.ObjectPath

And I noticed that the type was wrong, so I fixed it.