### PR TITLE
Do not request go.bluetooth name

### DIFF
--- a/api/service/app.go
+++ b/api/service/app.go
@@ -16,9 +16,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// AppInterface default namespace
-const AppInterface = "go.bluetooth"
-
 // AppPath default app path
 var AppPath = "/%s/apps/%d"
 
@@ -29,7 +26,6 @@ type AppOptions struct {
 	AdapterID         string
 	AgentCaps         string
 	AgentSetAsDefault bool
-	AppInterface      string
 	UUIDSuffix        string
 	UUID              string
 }
@@ -49,9 +45,6 @@ func NewApp(options AppOptions) (*App, error) {
 	}
 	if app.Options.UUID == "" {
 		app.Options.UUID = "1234"
-	}
-	if app.Options.AppInterface == "" {
-		app.Options.AppInterface = AppInterface
 	}
 
 	app.adapterID = app.Options.AdapterID
@@ -116,14 +109,6 @@ func (app *App) init() error {
 		return err
 	}
 	app.conn = conn
-
-	_, err = conn.RequestName(
-		app.Options.AppInterface,
-		dbus.NameFlagDoNotQueue&dbus.NameFlagReplaceExisting,
-	)
-	if err != nil {
-		return err
-	}
 
 	om, err := api.NewDBusObjectManager(app.DBusConn())
 	if err != nil {


### PR DESCRIPTION
Previously I would get the following error while creating a service:

    Connection ":1.8260" is not allowed to own the service "go.bluetooth" due to security policies in the configuration file

This PR fixes that by not requesting the go.bluetooth name. I can now create a service, while running as a normal user and without changing any system settings (on a laptop running Debian buster, with bluez 5.50).

---

I'm not sure whether this is the right fix, maybe registering the name serves a purpose. I couldn't find one so I simply deleted it in this PR.