### PR TITLE
actually make the defers get called

### DIFF
--- a/examples/discovery/discovery.go
+++ b/examples/discovery/discovery.go
@@ -3,6 +3,8 @@ package discovery_example
 
 import (
 	"context"
+	"os"
+	"os/signal"
 
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/api/beacon"
@@ -63,7 +65,13 @@ func Run(adapterID string, onlyBeacon bool) error {
 
 	}()
 
-	select {}
+	ch := make(chan os.Signal)
+	signal.Notify(ch, os.Interrupt, os.Kill) // get notified of all OS signals
+
+	sig := <-ch
+	log.Infof("Received signal [%v]; shutting down...\n", sig)
+
+	return nil
 }
 
 func handleBeacon(dev *device.Device1) error {


### PR DESCRIPTION
This is **not** to be merged. I'm only opening this as a point of reference, because it seems that examples/discovery.go has some issues uncovers one that might be a root cause of a deadlock.

I didn't want to make too many changes to confuse the issue, but I think this one change might be unmasking the issues that I'm hitting.

# dbus lock
My change will force the two defers in the discovery.Run function to be called. As this is an example, I assume that this cleanup should be done. The first defer is the cancel() for the the api.Discover(), which itself is the dbus RemoveSignal in dbus/default_handler.go, which will block waiting for a Lock.

A possibly related issue: As it is, discovery.go will block in 
`	isBeacon := <-beaconUpdated` [here](https://github.com/muka/go-bluetooth/blob/c69565a982b8f5954bee8a4e58e4ed845f825830/examples/discovery/discovery.go#L81)

which I found was also waiting on a lock in dbus/default_handler.go. I thought it might be because it was blocked on writing to a channel, putting the reading of beaconUpdated in a goroutine works better. But, it still seems like there's an issue with locks in dbus.

I tried updating to dbus 5.0.3. The stack trace is different, but it still seems like it's waiting on something.

# circular lock
Another point of confusion for me, which I have been trying to figure out. (Maybe it's just that I'm not getting the code)
- in beacon.go, handleBeacon(), it seems like this case statement:
```
			case <-ctx.Done():
				propchanged <- nil
				close(ch)
				break
			}
```
is writing to a channel that it is expecting the previous case statement:
```
			case changed := <-propchanged:

				if changed == nil {
					ctx.Done()
					return
				}
```
to read. But, of course, it's blocking on writing, so that other case statement won't get reached. (The propChanged channel is created in bluez/props.go and it is only written to in that function.)
