### PR TITLE
Use v5 of the dbus package

### DIFF
--- a/api/advertisement.go
+++ b/api/advertisement.go
@@ -3,7 +3,7 @@ package api
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/advertising"
 	log "github.com/sirupsen/logrus"

--- a/api/beacon/beacon.go
+++ b/api/beacon/beacon.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez/profile/advertising"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 )

--- a/api/object_manager_service.go
+++ b/api/object_manager_service.go
@@ -3,7 +3,7 @@ package api
 import (
 	"errors"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile"
 	log "github.com/sirupsen/logrus"

--- a/api/properties_service.go
+++ b/api/properties_service.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"github.com/fatih/structs"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
-	"github.com/godbus/dbus/prop"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/godbus/dbus/v5/prop"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile"
 	"github.com/muka/go-bluetooth/props"

--- a/api/service/app.go
+++ b/api/service/app.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"

--- a/api/service/app_char.go
+++ b/api/service/app_char.go
@@ -3,7 +3,7 @@ package service
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"

--- a/api/service/app_char_rw.go
+++ b/api/service/app_char_rw.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/api/service/app_descr.go
+++ b/api/service/app_descr.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"

--- a/api/service/app_descr_rw.go
+++ b/api/service/app_descr_rw.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/api/service/app_getter.go
+++ b/api/service/app_getter.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"
 	"github.com/muka/go-bluetooth/bluez/profile/agent"

--- a/api/service/app_service.go
+++ b/api/service/app_service.go
@@ -3,7 +3,7 @@ package service
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"

--- a/api/service/app_service_mgm.go
+++ b/api/service/app_service_mgm.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"

--- a/api/service_expose.go
+++ b/api/service_expose.go
@@ -1,9 +1,9 @@
 package api
 
 import (
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
-	"github.com/godbus/dbus/prop"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/godbus/dbus/v5/prop"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"
 )

--- a/bluez/bluez.go
+++ b/bluez/bluez.go
@@ -1,6 +1,6 @@
 package bluez
 
-import "github.com/godbus/dbus/introspect"
+import "github.com/godbus/dbus/v5/introspect"
 
 const (
 	OrgBluezPath      = "/org/bluez"

--- a/bluez/client.go
+++ b/bluez/client.go
@@ -3,7 +3,7 @@ package bluez
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/util"
 )
 

--- a/bluez/dbus.go
+++ b/bluez/dbus.go
@@ -3,14 +3,14 @@ package bluez
 import (
 	"errors"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	log "github.com/sirupsen/logrus"
 )
 
 //Properties dbus serializable struct
 // Use struct tags to control how the field is handled by Properties interface
 // Example: field `dbus:writable,emit,myCallback`
-// See Prop in github.com/godbus/dbus/prop for configuration details
+// See Prop in github.com/godbus/dbus/v5/prop for configuration details
 // Options:
 // - writable: set the property as writable (Set will updated it). Omit for read-only
 // - emit|invalidates: emit PropertyChanged, invalidates emit without disclosing the value. Omit for read-only

--- a/bluez/introspect.go
+++ b/bluez/introspect.go
@@ -1,6 +1,6 @@
 package bluez
 
-import "github.com/godbus/dbus/introspect"
+import "github.com/godbus/dbus/v5/introspect"
 
 // GattService1IntrospectDataString interface definition
 const GattService1IntrospectDataString = `

--- a/bluez/object_manager.go
+++ b/bluez/object_manager.go
@@ -1,7 +1,7 @@
 package bluez
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 var objectManager *ObjectManager

--- a/bluez/profile/adapter/adapter.go
+++ b/bluez/profile/adapter/adapter.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 )

--- a/bluez/profile/adapter/adapter_devices.go
+++ b/bluez/profile/adapter/adapter_devices.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 	"github.com/muka/go-bluetooth/util"

--- a/bluez/profile/adapter/adapter_discovery.go
+++ b/bluez/profile/adapter/adapter_discovery.go
@@ -1,7 +1,7 @@
 package adapter
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 	log "github.com/sirupsen/logrus"

--- a/bluez/profile/adapter/adapter_test.go
+++ b/bluez/profile/adapter/adapter_test.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 )
 

--- a/bluez/profile/adapter/gen_Adapter1.go
+++ b/bluez/profile/adapter/gen_Adapter1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
    "fmt"
 )
 

--- a/bluez/profile/advertising/gen_LEAdvertisement1.go
+++ b/bluez/profile/advertising/gen_LEAdvertisement1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var LEAdvertisement1Interface = "org.bluez.LEAdvertisement1"

--- a/bluez/profile/advertising/gen_LEAdvertisingManager1.go
+++ b/bluez/profile/advertising/gen_LEAdvertisingManager1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
    "fmt"
 )
 

--- a/bluez/profile/agent/agent.go
+++ b/bluez/profile/agent/agent.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/introspect"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"
 	log "github.com/sirupsen/logrus"

--- a/bluez/profile/agent/agent_simple.go
+++ b/bluez/profile/agent/agent_simple.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"
 	log "github.com/sirupsen/logrus"
 )

--- a/bluez/profile/agent/gen_Agent1.go
+++ b/bluez/profile/agent/gen_Agent1.go
@@ -7,7 +7,7 @@ package agent
 import (
    "sync"
    "github.com/muka/go-bluetooth/bluez"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Agent1Interface = "org.bluez.Agent1"

--- a/bluez/profile/agent/gen_AgentManager1.go
+++ b/bluez/profile/agent/gen_AgentManager1.go
@@ -7,7 +7,7 @@ package agent
 import (
    "sync"
    "github.com/muka/go-bluetooth/bluez"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var AgentManager1Interface = "org.bluez.AgentManager1"

--- a/bluez/profile/battery/gen_Battery1.go
+++ b/bluez/profile/battery/gen_Battery1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Battery1Interface = "org.bluez.Battery1"

--- a/bluez/profile/device/device.go
+++ b/bluez/profile/device/device.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"
 )

--- a/bluez/profile/device/gen_Device1.go
+++ b/bluez/profile/device/gen_Device1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Device1Interface = "org.bluez.Device1"

--- a/bluez/profile/gatt/gen_GattCharacteristic1.go
+++ b/bluez/profile/gatt/gen_GattCharacteristic1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var GattCharacteristic1Interface = "org.bluez.GattCharacteristic1"

--- a/bluez/profile/gatt/gen_GattDescriptor1.go
+++ b/bluez/profile/gatt/gen_GattDescriptor1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var GattDescriptor1Interface = "org.bluez.GattDescriptor1"

--- a/bluez/profile/gatt/gen_GattManager1.go
+++ b/bluez/profile/gatt/gen_GattManager1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
    "fmt"
 )
 

--- a/bluez/profile/gatt/gen_GattProfile1.go
+++ b/bluez/profile/gatt/gen_GattProfile1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var GattProfile1Interface = "org.bluez.GattProfile1"

--- a/bluez/profile/gatt/gen_GattService1.go
+++ b/bluez/profile/gatt/gen_GattService1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var GattService1Interface = "org.bluez.GattService1"

--- a/bluez/profile/gen_errors.go
+++ b/bluez/profile/gen_errors.go
@@ -3,7 +3,7 @@
 package profile
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 var (

--- a/bluez/profile/health/gen_HealthChannel1.go
+++ b/bluez/profile/health/gen_HealthChannel1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var HealthChannel1Interface = "org.bluez.HealthChannel1"

--- a/bluez/profile/health/gen_HealthDevice1.go
+++ b/bluez/profile/health/gen_HealthDevice1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var HealthDevice1Interface = "org.bluez.HealthDevice1"

--- a/bluez/profile/health/gen_HealthManager1.go
+++ b/bluez/profile/health/gen_HealthManager1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var HealthManager1Interface = "org.bluez.HealthManager1"

--- a/bluez/profile/input/gen_Input1.go
+++ b/bluez/profile/input/gen_Input1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Input1Interface = "org.bluez.Input1"

--- a/bluez/profile/media/gen_Media1.go
+++ b/bluez/profile/media/gen_Media1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Media1Interface = "org.bluez.Media1"

--- a/bluez/profile/media/gen_MediaControl1.go
+++ b/bluez/profile/media/gen_MediaControl1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
    "fmt"
 )
 

--- a/bluez/profile/media/gen_MediaEndpoint1.go
+++ b/bluez/profile/media/gen_MediaEndpoint1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MediaEndpoint1Interface = "org.bluez.MediaEndpoint1"

--- a/bluez/profile/media/gen_MediaFolder1.go
+++ b/bluez/profile/media/gen_MediaFolder1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MediaFolder1Interface = "org.bluez.MediaFolder1"

--- a/bluez/profile/media/gen_MediaItem1.go
+++ b/bluez/profile/media/gen_MediaItem1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MediaItem1Interface = "org.bluez.MediaItem1"

--- a/bluez/profile/media/gen_MediaPlayer1.go
+++ b/bluez/profile/media/gen_MediaPlayer1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MediaPlayer1Interface = "org.bluez.MediaPlayer1"

--- a/bluez/profile/media/gen_MediaTransport1.go
+++ b/bluez/profile/media/gen_MediaTransport1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MediaTransport1Interface = "org.bluez.MediaTransport1"

--- a/bluez/profile/network/gen_Network1.go
+++ b/bluez/profile/network/gen_Network1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Network1Interface = "org.bluez.Network1"

--- a/bluez/profile/network/gen_NetworkServer1.go
+++ b/bluez/profile/network/gen_NetworkServer1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var NetworkServer1Interface = "org.bluez.NetworkServer1"

--- a/bluez/profile/obex/Client1.go
+++ b/bluez/profile/obex/Client1.go
@@ -1,7 +1,7 @@
 package obex
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"
 )

--- a/bluez/profile/obex/ObjectPush1.go
+++ b/bluez/profile/obex/ObjectPush1.go
@@ -1,7 +1,7 @@
 package obex
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	"github.com/muka/go-bluetooth/util"
 )

--- a/bluez/profile/obex/Session1.go
+++ b/bluez/profile/obex/Session1.go
@@ -1,7 +1,7 @@
 package obex
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"
 )

--- a/bluez/profile/obex/Transfer1.go
+++ b/bluez/profile/obex/Transfer1.go
@@ -1,7 +1,7 @@
 package obex
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"
 )

--- a/bluez/profile/obex/gen_FileTransfer.go
+++ b/bluez/profile/obex/gen_FileTransfer.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var FileTransferInterface = "org.bluez.obex.FileTransfer"

--- a/bluez/profile/obex/gen_Message1.go
+++ b/bluez/profile/obex/gen_Message1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Message1Interface = "org.bluez.obex.Message1"

--- a/bluez/profile/obex/gen_MessageAccess1.go
+++ b/bluez/profile/obex/gen_MessageAccess1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var MessageAccess1Interface = "org.bluez.obex.MessageAccess1"

--- a/bluez/profile/obex/gen_PhonebookAccess1.go
+++ b/bluez/profile/obex/gen_PhonebookAccess1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var PhonebookAccess1Interface = "org.bluez.obex.PhonebookAccess1"

--- a/bluez/profile/obex/gen_Synchronization1.go
+++ b/bluez/profile/obex/gen_Synchronization1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Synchronization1Interface = "org.bluez.obex.Synchronization1"

--- a/bluez/profile/obex_agent/gen_Agent1.go
+++ b/bluez/profile/obex_agent/gen_Agent1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Agent1Interface = "org.bluez.obex.Agent1"

--- a/bluez/profile/obex_agent/gen_AgentManager1.go
+++ b/bluez/profile/obex_agent/gen_AgentManager1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var AgentManager1Interface = "org.bluez.obex.AgentManager1"

--- a/bluez/profile/profile.go
+++ b/bluez/profile/profile.go
@@ -1,6 +1,6 @@
 package profile
 
-import "github.com/godbus/dbus"
+import "github.com/godbus/dbus/v5"
 
 // BluezApi is the shared interface for the Bluez API implmentation
 type BluezApi interface {

--- a/bluez/profile/profile/gen_Profile1.go
+++ b/bluez/profile/profile/gen_Profile1.go
@@ -7,7 +7,7 @@ package profile
 import (
    "sync"
    "github.com/muka/go-bluetooth/bluez"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Profile1Interface = "org.bluez.Profile1"

--- a/bluez/profile/profile/gen_ProfileManager1.go
+++ b/bluez/profile/profile/gen_ProfileManager1.go
@@ -7,7 +7,7 @@ package profile
 import (
    "sync"
    "github.com/muka/go-bluetooth/bluez"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var ProfileManager1Interface = "org.bluez.ProfileManager1"

--- a/bluez/profile/sap/gen_SimAccess1.go
+++ b/bluez/profile/sap/gen_SimAccess1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var SimAccess1Interface = "org.bluez.SimAccess1"

--- a/bluez/profile/thermometer/gen_Thermometer1.go
+++ b/bluez/profile/thermometer/gen_Thermometer1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var Thermometer1Interface = "org.bluez.Thermometer1"

--- a/bluez/profile/thermometer/gen_ThermometerManager1.go
+++ b/bluez/profile/thermometer/gen_ThermometerManager1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var ThermometerManager1Interface = "org.bluez.ThermometerManager1"

--- a/bluez/profile/thermometer/gen_ThermometerWatcher1.go
+++ b/bluez/profile/thermometer/gen_ThermometerWatcher1.go
@@ -9,7 +9,7 @@ import (
    "github.com/muka/go-bluetooth/bluez"
    "github.com/muka/go-bluetooth/util"
    "github.com/muka/go-bluetooth/props"
-   "github.com/godbus/dbus"
+   "github.com/godbus/dbus/v5"
 )
 
 var ThermometerWatcher1Interface = "org.bluez.ThermometerWatcher1"

--- a/bluez/props.go
+++ b/bluez/props.go
@@ -3,7 +3,7 @@ package bluez
 import (
 	"reflect"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/util"
 	log "github.com/sirupsen/logrus"
 )

--- a/devices/sensortag/sensortag.go
+++ b/devices/sensortag/sensortag.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/bluez/profile/device"
 	"github.com/muka/go-bluetooth/bluez/profile/gatt"
 	log "github.com/sirupsen/logrus"

--- a/examples/agent/agent.go
+++ b/examples/agent/agent.go
@@ -3,7 +3,7 @@ package agent_example
 import (
 	"fmt"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"
 	"github.com/muka/go-bluetooth/bluez/profile/agent"

--- a/examples/service/client.go
+++ b/examples/service/client.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/muka/go-bluetooth/api"
 	"github.com/muka/go-bluetooth/bluez/profile/adapter"
 	"github.com/muka/go-bluetooth/bluez/profile/agent"

--- a/gen/generator/generator_tpl_api.go
+++ b/gen/generator/generator_tpl_api.go
@@ -192,7 +192,7 @@ func ApiTemplate(filename string, api *types.Api, apiGroup *types.ApiGroup) erro
 	}
 
 	if importDbus {
-		imports = append(imports, "github.com/godbus/dbus")
+		imports = append(imports, "github.com/godbus/dbus/v5")
 	}
 
 	api.Description = prepareDocs(api.Description, false, 0)

--- a/gen/generator/tpl/errors.go.tpl
+++ b/gen/generator/tpl/errors.go.tpl
@@ -3,7 +3,7 @@
 package profile
 
 import (
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/fatih/structs v1.1.0
-	github.com/godbus/dbus v4.1.0+incompatible
+	github.com/godbus/dbus/v5 v5.0.3
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
-github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
+github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/props/props.go
+++ b/props/props.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/fatih/structs"
-	"github.com/godbus/dbus"
-	"github.com/godbus/dbus/prop"
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/prop"
 	"github.com/muka/go-bluetooth/bluez"
 	log "github.com/sirupsen/logrus"
 )

--- a/util/map_struct.go
+++ b/util/map_struct.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/util/map_struct_test.go
+++ b/util/map_struct_test.go
@@ -3,7 +3,7 @@ package util
 import (
 	"testing"
 
-	"github.com/godbus/dbus"
+	"github.com/godbus/dbus/v5"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This version starts using Go modules, so that required a large number of changes to import paths. I need this for some new features in the v5 branch of the DBus package.

The _examples folder still needs to be updated, it may need to be updated after this PR is merged.

I ran `make gen` to update the import paths in the generated files. This also caused a large number of other changes which I did not add, I don't know what caused these changes.