### PR TITLE
Deferred panic capture on OnDeviceDiscovered if scan reports come in after discovery is stopped

### DIFF
--- a/bluez/profile/adapter/adapter_discovery.go
+++ b/bluez/profile/adapter/adapter_discovery.go
@@ -35,6 +35,16 @@ func (a *Adapter1) OnDeviceDiscovered() (chan *DeviceDiscovered, func(), error) 
 	)
 
 	go func() {
+		// Recover from panic on write to closed channel which happens
+		// very often when there's too many BLE advertisements to process
+		// in timly manner by bluez+dbus and advertising reports come in
+		// after scanning was stopped
+		defer func() {
+			if err := recover(); err != nil {
+				log.Warnf("Recovering from panic: %s", err)
+			}
+		}()
+
 		for v := range signal {
 
 			if v == nil {

--- a/bluez/props.go
+++ b/bluez/props.go
@@ -28,6 +28,12 @@ func WatchProperties(wprop WatchableClient) (chan *PropertyChanged, error) {
 	ch := make(chan *PropertyChanged)
 
 	go (func() {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Warnf("Recovering from panic in SetWatchPropertiesChannel: %s", err)
+			}
+		}()
+
 		for {
 
 			if channel == nil {
@@ -92,6 +98,11 @@ func WatchProperties(wprop WatchableClient) (chan *PropertyChanged, error) {
 }
 
 func UnwatchProperties(wprop WatchableClient, ch chan *PropertyChanged) error {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Warnf("Recovering from panic in UnwatchProperties: %s", err)
+		}
+	}()
 	if wprop.GetWatchPropertiesChannel() != nil {
 		wprop.GetWatchPropertiesChannel() <- nil
 		err := wprop.Client().Unregister(wprop.Path(), PropertiesInterface, wprop.GetWatchPropertiesChannel())


### PR DESCRIPTION
This merge request recovers from a panic caused by writing to a non existing channel when scan results come in after scanning was stopped. This happens very very often in very BLE polluted areas on CPU constrained devices.

The cause was the following:

1. Scanning is stated
2. Results come in...
3. Scanning is stopped
4. More results come in
5. Until they stop coming

The crash occurred between steps 3. and 4. Now it's possible to recover from it so the whole application doesn't crash.
Suspected reason for this is that the results are still coming from a Bluez or HCI dongle RX buffer.