### PR TITLE
handle empty hciconfig response to avoid panic

### DIFF
--- a/hw/linux/hciconfig/hciconfig.go
+++ b/hw/linux/hciconfig/hciconfig.go
@@ -1,6 +1,7 @@
 package hciconfig
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/muka/go-bluetooth/hw/linux/cmd"
@@ -12,6 +13,10 @@ func GetAdapters() ([]HCIConfigResult, error) {
 	out, err := cmd.Exec("hciconfig")
 	if err != nil {
 		return nil, err
+	}
+
+	if len(out) == 0 {
+		return nil, errors.New("hciconfig provided no response")
 	}
 
 	list := []HCIConfigResult{}


### PR DESCRIPTION
Refer to issue https://github.com/muka/go-bluetooth/issues/134

```go
hciconfig.GetAdatpers()
```
is raising a panic execption in case no BT device is connected. Similar to the corresponding `btmgmt.GetAdapers()` function it will raise an defined error, which can be handeled afterwards.

hciconfig_test.go log:
```
--- FAIL: TestGetAdapters (0.00s)
    /home/thierolm/evcc/git/go-bluetooth/hw/linux/hciconfig/hciconfig_test.go:43: hciconfig provided no response
```