### PR TITLE
Bugfixes/advertisement

### DIFF
--- a/api/service/app_advertise.go
+++ b/api/service/app_advertise.go
@@ -13,9 +13,6 @@ func (app *App) Advertise(timeout uint32) (func(), error) {
 
 	adv := app.GetAdvertisement()
 
-	adv.Timeout = uint16(timeout)
-	adv.Duration = uint16(timeout)
-
 	for _, svc := range app.GetServices() {
 		adv.ServiceUUIDs = append(adv.ServiceUUIDs, svc.UUID)
 	}

--- a/api/service/app_advertise.go
+++ b/api/service/app_advertise.go
@@ -16,9 +16,8 @@ func (app *App) Advertise(timeout uint32) (func(), error) {
 	adv.Timeout = uint16(timeout)
 	adv.Duration = uint16(timeout)
 
-	serviceUUIDs := []string{}
-	for serviceUUID := range app.GetServices() {
-		serviceUUIDs = append(serviceUUIDs, string(serviceUUID))
+	for _, svc := range app.GetServices() {
+		adv.ServiceUUIDs = append(adv.ServiceUUIDs, svc.UUID)
 	}
 
 	cancel, err := api.ExposeAdvertisement(app.adapterID, adv, timeout)


### PR DESCRIPTION
I was experiencing issues with advertisements not working properly.

1. service ids didn't not propagate for the device.
2. discovery of the device itself was spotty until I removed the setting of the duration/timeouts equal to the advertisement timeout