### PR TITLE
Bluez/client expose dbus connection and object

### DIFF
--- a/bluez/client.go
+++ b/bluez/client.go
@@ -68,6 +68,16 @@ func (c *Client) Call(method string, flags dbus.Flags, args ...interface{}) *dbu
 	return c.dbusObject.Call(methodPath, flags, args...)
 }
 
+//GetConnection returns the Dbus connection
+func (c *Client) GetConnection() *dbus.Conn {
+	return c.conn
+}
+
+//GetDbusObject returns the Dbus object
+func (c *Client) GetDbusObject() dbus.BusObject {
+	return c.dbusObject
+}
+
 //GetProperty return a property value
 func (c *Client) GetProperty(p string) (dbus.Variant, error) {
 	if !c.isConnected() {


### PR DESCRIPTION
Hi Muka,

I need those exposed to use with specific Profile1 interface that I've implemented with dbus-codegen-go. I would appreciate if you can validate this change to avoid using a forked version of your project ! 
