### PR TITLE
Overridden types not propagated

### DIFF
--- a/bluez/profile/advertising/gen_LEAdvertisement1.go
+++ b/bluez/profile/advertising/gen_LEAdvertisement1.go
@@ -230,17 +230,17 @@ func (a *LEAdvertisement1) GetAppearance() (uint16, error) {
 }
 
 // SetData set Data value
-func (a *LEAdvertisement1) SetData(v map[string]interface{}) error {
+func (a *LEAdvertisement1) SetData(v map[byte]interface{}) error {
 	return a.SetProperty("Data", v)
 }
 
 // GetData get Data value
-func (a *LEAdvertisement1) GetData() (map[string]interface{}, error) {
+func (a *LEAdvertisement1) GetData() (map[byte]interface{}, error) {
 	v, err := a.GetProperty("Data")
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return v.Value().(map[string]interface{}), nil
+	return v.Value().(map[byte]interface{}), nil
 }
 
 // SetDiscoverable set Discoverable value
@@ -314,17 +314,17 @@ func (a *LEAdvertisement1) GetLocalName() (string, error) {
 }
 
 // SetManufacturerData set ManufacturerData value
-func (a *LEAdvertisement1) SetManufacturerData(v map[string]interface{}) error {
+func (a *LEAdvertisement1) SetManufacturerData(v map[uint16]interface{}) error {
 	return a.SetProperty("ManufacturerData", v)
 }
 
 // GetManufacturerData get ManufacturerData value
-func (a *LEAdvertisement1) GetManufacturerData() (map[string]interface{}, error) {
+func (a *LEAdvertisement1) GetManufacturerData() (map[uint16]interface{}, error) {
 	v, err := a.GetProperty("ManufacturerData")
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return v.Value().(map[string]interface{}), nil
+	return v.Value().(map[uint16]interface{}), nil
 }
 
 // SetMaxInterval set MaxInterval value

--- a/bluez/profile/advertising/gen_LEAdvertisement1.go
+++ b/bluez/profile/advertising/gen_LEAdvertisement1.go
@@ -238,7 +238,7 @@ func (a *LEAdvertisement1) SetData(v map[byte]interface{}) error {
 func (a *LEAdvertisement1) GetData() (map[byte]interface{}, error) {
 	v, err := a.GetProperty("Data")
 	if err != nil {
-		return map[string]interface{}{}, err
+		return map[byte]interface{}{}, err
 	}
 	return v.Value().(map[byte]interface{}), nil
 }
@@ -322,7 +322,7 @@ func (a *LEAdvertisement1) SetManufacturerData(v map[uint16]interface{}) error {
 func (a *LEAdvertisement1) GetManufacturerData() (map[uint16]interface{}, error) {
 	v, err := a.GetProperty("ManufacturerData")
 	if err != nil {
-		return map[string]interface{}{}, err
+		return map[uint16]interface{}{}, err
 	}
 	return v.Value().(map[uint16]interface{}), nil
 }

--- a/bluez/profile/device/gen_Device1.go
+++ b/bluez/profile/device/gen_Device1.go
@@ -409,17 +409,17 @@ func (a *Device1) GetLegacyPairing() (bool, error) {
 }
 
 // SetManufacturerData set ManufacturerData value
-func (a *Device1) SetManufacturerData(v map[string]interface{}) error {
+func (a *Device1) SetManufacturerData(v map[uint16]interface{}) error {
 	return a.SetProperty("ManufacturerData", v)
 }
 
 // GetManufacturerData get ManufacturerData value
-func (a *Device1) GetManufacturerData() (map[string]interface{}, error) {
+func (a *Device1) GetManufacturerData() (map[uint16]interface{}, error) {
 	v, err := a.GetProperty("ManufacturerData")
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return v.Value().(map[string]interface{}), nil
+	return v.Value().(map[uint16]interface{}), nil
 }
 
 // SetModalias set Modalias value

--- a/bluez/profile/device/gen_Device1.go
+++ b/bluez/profile/device/gen_Device1.go
@@ -417,7 +417,7 @@ func (a *Device1) SetManufacturerData(v map[uint16]interface{}) error {
 func (a *Device1) GetManufacturerData() (map[uint16]interface{}, error) {
 	v, err := a.GetProperty("ManufacturerData")
 	if err != nil {
-		return map[string]interface{}{}, err
+		return map[uint16]interface{}{}, err
 	}
 	return v.Value().(map[uint16]interface{}), nil
 }

--- a/bluez/profile/media/gen_MediaPlayer1.go
+++ b/bluez/profile/media/gen_MediaPlayer1.go
@@ -474,7 +474,7 @@ func (a *MediaPlayer1) SetTrack(v Track) error {
 func (a *MediaPlayer1) GetTrack() (Track, error) {
 	v, err := a.GetProperty("Track")
 	if err != nil {
-		return map[string]interface{}{}, err
+		return Track{}, err
 	}
 	return v.Value().(Track), nil
 }

--- a/bluez/profile/media/gen_MediaPlayer1.go
+++ b/bluez/profile/media/gen_MediaPlayer1.go
@@ -466,17 +466,17 @@ func (a *MediaPlayer1) GetTitle() (string, error) {
 }
 
 // SetTrack set Track value
-func (a *MediaPlayer1) SetTrack(v map[string]interface{}) error {
+func (a *MediaPlayer1) SetTrack(v Track) error {
 	return a.SetProperty("Track", v)
 }
 
 // GetTrack get Track value
-func (a *MediaPlayer1) GetTrack() (map[string]interface{}, error) {
+func (a *MediaPlayer1) GetTrack() (Track, error) {
 	v, err := a.GetProperty("Track")
 	if err != nil {
 		return map[string]interface{}{}, err
 	}
-	return v.Value().(map[string]interface{}), nil
+	return v.Value().(Track), nil
 }
 
 // SetTrackNumber set TrackNumber value

--- a/gen/generator/generator_tpl_api.go
+++ b/gen/generator/generator_tpl_api.go
@@ -86,10 +86,10 @@ func ApiTemplate(filename string, api *types.Api, apiGroup *types.ApiGroup) erro
 					log.Errorf("Override %s %s: %s", api.Interface, prop.Name, err)
 				}
 
-				prop.RawType = getRawType(prop.Property.Type)
 				prop.RawTypeInitializer = rawTypeInitializer
 				prop.Property.Type = propType
-				// log.Debugf("props --> %s %s", propName, propType)
+				prop.RawType = getRawType(prop.Property.Type)
+				//log.Debugf("props --> %s %s", propName, propType)
 			} else {
 
 				rawTypeInitializer, err := getRawTypeInitializer(propType)

--- a/gen/generator/generator_tpl_api.go
+++ b/gen/generator/generator_tpl_api.go
@@ -81,13 +81,13 @@ func ApiTemplate(filename string, api *types.Api, apiGroup *types.ApiGroup) erro
 				prop = propsList[propName]
 				log.Debugf("\tUsing overridden property %s", propName)
 
+				prop.Property.Type = propType
 				rawTypeInitializer, err := getRawTypeInitializer(prop.Property.Type)
 				if err != nil {
 					log.Errorf("Override %s %s: %s", api.Interface, prop.Name, err)
 				}
 
 				prop.RawTypeInitializer = rawTypeInitializer
-				prop.Property.Type = propType
 				prop.RawType = getRawType(prop.Property.Type)
 				//log.Debugf("props --> %s %s", propName, propType)
 			} else {

--- a/gen/generator/generator_types.go
+++ b/gen/generator/generator_types.go
@@ -167,6 +167,8 @@ func getRawTypeInitializer(t string) (string, error) {
 		return "dbus.ObjectPath(\"\")", nil
 	case "dbus.objectpath":
 		return "dbus.ObjectPath(\"\")", nil
+	case "Track":
+		return "Track{}", nil
 	}
 
 	return "", fmt.Errorf("unknown type: %s", t)


### PR DESCRIPTION
Properties were generated with the correct overridden type, but the raw type was being computed prior to storing the overridden  value. This fixes the method generation by ensuring the overridden type is stored prior to raw type compute.