### PR TITLE
Ignore fields that are not found in MapToStruct

### DIFF
--- a/util/map_struct.go
+++ b/util/map_struct.go
@@ -68,7 +68,7 @@ func mapStructField(obj interface{}, name string, value dbus.Variant) error {
 	structFieldValue := structValue.FieldByName(name)
 
 	if !structFieldValue.IsValid() {
-		return fmt.Errorf("Field not found: %s", name)
+		return nil
 	}
 
 	if !structFieldValue.CanSet() {


### PR DESCRIPTION
This PR returns nil rather than an error when a field isn't found. This change prevents the library from breaking every time BlueZ decides to add a new field to their API.

Fixes #169 