### PR TITLE
Revert back to reflect.Ptr

### DIFF
--- a/util/map_struct.go
+++ b/util/map_struct.go
@@ -90,11 +90,11 @@ func mapStructField(obj interface{}, name string, value dbus.Variant) error {
 	if val.Type().Kind() == reflect.Map {
 
 		if structFieldType.Kind() == reflect.Struct ||
-			(structFieldType.Kind() == reflect.Pointer && structFieldType.Elem().Kind() == reflect.Struct) {
+			(structFieldType.Kind() == reflect.Ptr && structFieldType.Elem().Kind() == reflect.Struct) {
 
 			variantMap, ok := value.Value().(map[string]dbus.Variant)
 			if ok {
-				if structFieldType.Kind() == reflect.Pointer {
+				if structFieldType.Kind() == reflect.Ptr {
 					if structFieldValue.IsZero() {
 						return fmt.Errorf("Pointer field %s: uninitialized", name)
 					}


### PR DESCRIPTION
This allows the module to be compiled using Go 1.14, as specified in the go.mod file.

`reflect.Ptr` was renamed to `reflect.Pointer` in Go 1.18 (see https://tip.golang.org/doc/go1.18). The code uses `reflect.Pointer` despite the go.mod file specifying a minimum Go version of 1.14. So either the go.mod file needs to be updated or the code should revert back to `reflect.Ptr` for as long as Go 1.14 is considered the minimum required version.