### PR TITLE
Fix beacon WatchDeviceChanges memory leak

### DIFF
--- a/api/beacon/beacon.go
+++ b/api/beacon/beacon.go
@@ -58,12 +58,12 @@ func (b *Beacon) WatchDeviceChanges(ctx context.Context) (chan bool, error) {
 	ch := make(chan bool)
 
 	go func() {
+		defer close(ch)
 		for {
 			select {
 			case changed := <-b.propchanged:
 
 				if changed == nil {
-					ctx.Done()
 					return
 				}
 
@@ -71,11 +71,8 @@ func (b *Beacon) WatchDeviceChanges(ctx context.Context) (chan bool, error) {
 					ch <- b.Parse()
 				}
 
-				break
 			case <-ctx.Done():
 				b.propchanged <- nil
-				close(ch)
-				break
 			}
 		}
 	}()

--- a/api/beacon/beacon.go
+++ b/api/beacon/beacon.go
@@ -73,6 +73,7 @@ func (b *Beacon) WatchDeviceChanges(ctx context.Context) (chan bool, error) {
 
 			case <-ctx.Done():
 				b.propchanged <- nil
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
The `WatchDeviceChanges` function creates a goroutine that watches for any change notifications coming from the underlying Device. The result of `b.Parse` is sent to the channel `ch` using a blocking send. Because of this, the caller to `WatchDeviceChanges` must continuously empty this channel otherise the goroutine will simply hang on this line, meaning it will never exit and result in a goroutine leak.  So the caller code looks something like this:

```go
	ch, err := b.WatchDeviceChanges(ctx)
	if err != nil {
        ...
    }

	// Make sure to empty the channel
	go func() {
		for range ch {}
	}()
```

This brings us onto the second issue: the channel `ch` is only closed when the context `ctx` is done. However, the goroutine can also exit due to `b.propchanged` sending a `nil`, which occurs when `UnwatchDeviceChanges` is called. In this case, `ch` is never closed, which means the caller to `WatchDeviceChanges` that is emptying `ch` will never quit, again resulting in a goroutine and channel leak. Closing the channel using a `defer` at the beginning of the goroutine resolves this issue.

In addition, when the context reports that it is done, instead of `return`ing from the function, it just breaks, which continues the loop and can potentially cause a panic if it tries to write to the channel `ch`.

The call to `ctx.Done` is meaningless on line 66. I'm guessing the intention was to cancel the context, which is not possible from this function.