### PR TITLE
Remove unnecessary send to b.propchanged

### DIFF
--- a/api/beacon/beacon.go
+++ b/api/beacon/beacon.go
@@ -73,7 +73,6 @@ func (b *Beacon) WatchDeviceChanges(ctx context.Context) (chan bool, error) {
 
 				break
 			case <-ctx.Done():
-				b.propchanged <- nil
 				close(ch)
 				break
 			}


### PR DESCRIPTION
Sending `nil` to `b.propchanged` when the context is done does not seem to serve any purpose. The `bluez.WatchProperties` function that creates `propchanged` does not read from it. The channel is also not accessible outside of the beacon.