### PR TITLE
Close dbus object to prevent goroutine leak

### DIFF
--- a/api/service/app.go
+++ b/api/service/app.go
@@ -235,4 +235,11 @@ func (app *App) Close() {
 			log.Warnf("GattManager1.UnregisterApplication: %s", err1)
 		}
 	}
+
+	if app.conn != nil {
+		err := app.conn.Close()
+		if err != nil {
+			log.Warnf("dbus.Conn.Close:: %s", err)
+		}
+	}
 }


### PR DESCRIPTION
Hello, this fixes the following goroutine leak. This output is made with https://github.com/uber-go/goleak.

```
             [Goroutine 34 in state chan receive, with github.com/godbus/dbus/v5.newConn.func1 on top of the stack:
        goroutine 34 [chan receive]:
        github.com/godbus/dbus/v5.newConn.func1()
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/conn.go:253 +0x70
        created by github.com/godbus/dbus/v5.newConn in goroutine 21
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/conn.go:252 +0x2c6
        
         Goroutine 35 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 35 [IO wait]:
        internal/poll.runtime_pollWait(0x7efe7c048de0, 0x72)
                /usr/lib/go/src/runtime/netpoll.go:343 +0x85
        internal/poll.(*pollDesc).wait(0xc00021a020, 0xc000421140?, 0x0)
                /usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0xb1
        internal/poll.(*pollDesc).waitRead(...)
                /usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).ReadMsg(0xc00021a000, {0xc000421140, 0x10, 0x10}, {0xc000196020, 0x1000, 0x1000}, 0xc0001bf9f0?)
                /usr/lib/go/src/internal/poll/fd_unix.go:301 +0x532
        net.(*netFD).readMsg(0xc00021a000, {0xc000421140, 0x10, 0x10}, {0xc000196020, 0x1000, 0x1000}, 0xd1a5e0?)
                /usr/lib/go/src/net/fd_posix.go:78 +0xa9
        net.(*UnixConn).readMsg(0xc00020c020, {0xc000421140, 0x10, 0x10}, {0xc000196020, 0x1000, 0x1000})
                /usr/lib/go/src/net/unixsock_posix.go:115 +0xb4
        net.(*UnixConn).ReadMsgUnix(0xc00020c020, {0xc000421140, 0x10, 0x10}, {0xc000196020, 0x1000, 0x1000})
                /usr/lib/go/src/net/unixsock.go:143 +0xbb
        github.com/godbus/dbus/v5.(*oobReader).Read(0xc000196000, {0xc000421140, 0x10, 0x10})
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/transport_unix.go:21 +0x99
        io.ReadAtLeast({0xf41420, 0xc000196000}, {0xc000421140, 0x10, 0x10}, 0x10)
                /usr/lib/go/src/io/io.go:335 +0xd0
        io.ReadFull(...)
                /usr/lib/go/src/io/io.go:354
        github.com/godbus/dbus/v5.(*unixTransport).ReadMessage(0xc000218000)
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/transport_unix.go:91 +0x288
        github.com/godbus/dbus/v5.(*Conn).inWorker(0xc00021e000)
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/conn.go:348 +0x5f
        created by github.com/godbus/dbus/v5.(*Conn).Auth in goroutine 21
                /home/go/pkg/mod/github.com/godbus/dbus/v5@v5.0.3/auth.go:118 +0xc8d
        ]
```
I didn't add goleak to https://github.com/muka/go-bluetooth/blob/master/api/service/app_test.go because it fails on my laptop
```
$ go test ./... -run TestApp
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose /hci0/apps/0/service12342233/char0/descriptor0 (org.bluez.GattDescriptor1)"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose Properties interface (/hci0/apps/0/service12342233/char0/descriptor0)"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.AddObject: /hci0/apps/0/service12342233/char0/descriptor0"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 UUID:\"12344455
-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.AddObject: /hci0/apps/0/service12342233/char0"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233/char0:map[org.bluez.GattCharacteristic1:map[Descriptors:@ao [\"/hci0/apps/0/service12342233/char0/descriptor0\"] Flags:@as [] Handle:@q 0 MTU:@q 0 Notifying:false S
ervice:@o \"/hci0/apps/0/service12342233\" UUID:\"12343344-0000-1000-8000-00805F9B34FB\" Value:@ay []]] /hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 
UUID:\"12344455-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
time="2023-09-27T17:02:06+02:00" level=trace msg="Added GATT Descriptor UUID=12344455-0000-1000-8000-00805F9B34FB /hci0/apps/0/service12342233/char0/descriptor0"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose /hci0/apps/0/service12342233/char0 (org.bluez.GattCharacteristic1)"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose Properties interface (/hci0/apps/0/service12342233/char0)"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.AddObject: /hci0/apps/0/service12342233/char0"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233/char0:map[org.bluez.GattCharacteristic1:map[Descriptors:@ao [\"/hci0/apps/0/service12342233/char0/descriptor0\"] Flags:@as [] Handle:@q 0 MTU:@q 0 Notifying:false S
ervice:@o \"/hci0/apps/0/service12342233\" UUID:\"12343344-0000-1000-8000-00805F9B34FB\" Value:@ay []]] /hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 
UUID:\"12344455-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.AddObject: /hci0/apps/0/service12342233"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233:map[org.bluez.GattService1:map[Characteristics:@ao [\"/hci0/apps/0/service12342233/char0\"] Handle:@q 0 Primary:true UUID:\"12342233-0000-1000-8000-00805F9B34FB\"]]
 /hci0/apps/0/service12342233/char0:map[org.bluez.GattCharacteristic1:map[Descriptors:@ao [\"/hci0/apps/0/service12342233/char0/descriptor0\"] Flags:@as [] Handle:@q 0 MTU:@q 0 Notifying:false Service:@o \"/hci0/apps/0/service12342233\" UUID:\"12343344-0000-1000-8000-00805F9B34FB\"
 Value:@ay []]] /hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 UUID:\"12344455-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
time="2023-09-27T17:02:06+02:00" level=trace msg="Added GATT Characteristic UUID=12343344-0000-1000-8000-00805F9B34FB /hci0/apps/0/service12342233/char0"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose /hci0/apps/0/service12342233 (org.bluez.GattService1)"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose Properties interface (/hci0/apps/0/service12342233)"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.AddObject: /hci0/apps/0/service12342233"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233:map[org.bluez.GattService1:map[Characteristics:@ao [\"/hci0/apps/0/service12342233/char0\"] Handle:@q 0 Primary:true UUID:\"12342233-0000-1000-8000-00805F9B34FB\"]]
 /hci0/apps/0/service12342233/char0:map[org.bluez.GattCharacteristic1:map[Descriptors:@ao [\"/hci0/apps/0/service12342233/char0/descriptor0\"] Flags:@as [] Handle:@q 0 MTU:@q 0 Notifying:false Service:@o \"/hci0/apps/0/service12342233\" UUID:\"12343344-0000-1000-8000-00805F9B34FB\"
 Value:@ay []]] /hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 UUID:\"12344455-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
time="2023-09-27T17:02:06+02:00" level=trace msg="Added GATT Service UUID=12342233-0000-1000-8000-00805F9B34FB /hci0/apps/0/service12342233"
time="2023-09-27T17:02:06+02:00" level=trace msg="Expose /hci0/apps/0 (org.freedesktop.DBus.ObjectManager)"
time="2023-09-27T17:02:06+02:00" level=trace msg="Exposing Agent1 at /agent/simple0"
time="2023-09-27T17:02:06+02:00" level=trace msg="ObjectManager.GetManagedObjects \n map[/hci0/apps/0/service12342233:map[org.bluez.GattService1:map[Characteristics:@ao [\"/hci0/apps/0/service12342233/char0\"] Handle:@q 0 Primary:true UUID:\"12342233-0000-1000-8000-00805F9B34FB\"]]
 /hci0/apps/0/service12342233/char0:map[org.bluez.GattCharacteristic1:map[Descriptors:@ao [\"/hci0/apps/0/service12342233/char0/descriptor0\"] Flags:@as [] Handle:@q 0 MTU:@q 0 Notifying:false Service:@o \"/hci0/apps/0/service12342233\" UUID:\"12343344-0000-1000-8000-00805F9B34FB\"
 Value:@ay []]] /hci0/apps/0/service12342233/char0/descriptor0:map[org.bluez.GattDescriptor1:map[Characteristic:@o \"/hci0/apps/0/service12342233/char0\" Flags:[\"read\", \"write\"] Handle:@q 0 UUID:\"12344455-0000-1000-8000-00805F9B34FB\" Value:@ay []]]]"
--- FAIL: TestApp (0.00s)
    app_test.go:61: No valid service object found
FAIL
FAIL    github.com/muka/go-bluetooth/api/service        0.007s
FAIL
```